### PR TITLE
Basic Inline commands

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5B6A4D08B0CCD52CCDC819EEEAAE10B7 /* Pods-TPPDF_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FBC652FF540FEA54EE65C9222344EB11 /* Pods-TPPDF_Example-dummy.m */; };
 		792037FD206CED7900C56D96 /* PDFGenerator+TextInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792037FB206CEA4600C56D96 /* PDFGenerator+TextInline.swift */; };
 		79203800206CF0EB00C56D96 /* PDFGenerator+ImageInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792037FE206CF0E400C56D96 /* PDFGenerator+ImageInline.swift */; };
+		796BFCE12072224B00CB8DE7 /* PDFGenerator+TableInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796BFCDF2072222600CB8DE7 /* PDFGenerator+TableInline.swift */; };
 		8D01B502BA0D3721AD3066732EA99CBD /* Pods-TPPDF_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EC5618E9464F0B85C78C826D6552B2F7 /* Pods-TPPDF_Tests-dummy.m */; };
 		A25970F20E0E42829396544F7FF47B1D /* PDFGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A733CBFF5DD71B04FDB75BC60DDC2079 /* PDFGenerator.swift */; };
 		A9E1A990958D0034FED9D256362B8D88 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AEF1AC243777A0B37A48FAC63B6450 /* Command.swift */; };
@@ -68,6 +69,7 @@
 		75319B4750A1D4F87DA04721D9C33366 /* Pods-TPPDF_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TPPDF_Example-resources.sh"; sourceTree = "<group>"; };
 		792037FB206CEA4600C56D96 /* PDFGenerator+TextInline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFGenerator+TextInline.swift"; sourceTree = "<group>"; };
 		792037FE206CF0E400C56D96 /* PDFGenerator+ImageInline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFGenerator+ImageInline.swift"; sourceTree = "<group>"; };
+		796BFCDF2072222600CB8DE7 /* PDFGenerator+TableInline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFGenerator+TableInline.swift"; sourceTree = "<group>"; };
 		8024FE3270E884F9FD724089CBA9172F /* Pods_TPPDF_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TPPDF_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8275826837E091D0ABC9AF087300C10F /* TPPDF-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TPPDF-umbrella.h"; sourceTree = "<group>"; };
 		8515A60A596F397A6B737DB3222DED70 /* Pods-TPPDF_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TPPDF_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 				D4022A3C1EE4C3F100AAA9A3 /* PDFGenerator+Methods.swift */,
 				D4022A3E1EE4C43200AAA9A3 /* PDFGenerator+Generation.swift */,
 				D4022A401EE4C57D00AAA9A3 /* PDFGenerator+Table.swift */,
+				796BFCDF2072222600CB8DE7 /* PDFGenerator+TableInline.swift */,
 				D4022A381EE4C2D200AAA9A3 /* PDFGenerator+DocumentInfo.swift */,
 				D4022A3A1EE4C34B00AAA9A3 /* PDFGenerator+Calculations.swift */,
 				D4022A361EE4C21800AAA9A3 /* PDFGenerator+Initialization.swift */,
@@ -361,7 +364,7 @@
 				LastUpgradeCheck = 0700;
 				TargetAttributes = {
 					FC6EBB3398BB217B61C97F01013F56B4 = {
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 0930;
 					};
 				};
 			};
@@ -417,6 +420,7 @@
 				3703960108494AC861B4FE4F0DD532BA /* PDFInfo.swift in Sources */,
 				79203800206CF0EB00C56D96 /* PDFGenerator+ImageInline.swift in Sources */,
 				B0820DEEB3BE9C7B592515F80FA3E56C /* TableStyle+Defaults.swift in Sources */,
+				796BFCE12072224B00CB8DE7 /* PDFGenerator+TableInline.swift in Sources */,
 				D4022A411EE4C57D00AAA9A3 /* PDFGenerator+Table.swift in Sources */,
 				D4022A451EE4C70400AAA9A3 /* PDFGenerator+Lines.swift in Sources */,
 				F6AFB2251471F7FB8766A8D9349168EE /* TableStyle.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		3703960108494AC861B4FE4F0DD532BA /* PDFInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306B432E1175F8F1E130E6AF82CA1DCB /* PDFInfo.swift */; };
 		448D1D493854C78AC2A9ADFEB44831BB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B63C6A64CF66340668996F78DA6BB482 /* UIKit.framework */; };
 		5B6A4D08B0CCD52CCDC819EEEAAE10B7 /* Pods-TPPDF_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FBC652FF540FEA54EE65C9222344EB11 /* Pods-TPPDF_Example-dummy.m */; };
+		792037FD206CED7900C56D96 /* PDFGenerator+TextInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792037FB206CEA4600C56D96 /* PDFGenerator+TextInline.swift */; };
+		79203800206CF0EB00C56D96 /* PDFGenerator+ImageInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792037FE206CF0E400C56D96 /* PDFGenerator+ImageInline.swift */; };
 		8D01B502BA0D3721AD3066732EA99CBD /* Pods-TPPDF_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EC5618E9464F0B85C78C826D6552B2F7 /* Pods-TPPDF_Tests-dummy.m */; };
 		A25970F20E0E42829396544F7FF47B1D /* PDFGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A733CBFF5DD71B04FDB75BC60DDC2079 /* PDFGenerator.swift */; };
 		A9E1A990958D0034FED9D256362B8D88 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AEF1AC243777A0B37A48FAC63B6450 /* Command.swift */; };
@@ -64,6 +66,8 @@
 		5823F7923A03A8F51F473D60FF4B14DE /* Pods-TPPDF_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TPPDF_Tests-umbrella.h"; sourceTree = "<group>"; };
 		72E3B00ACF1B798F9A1B188EB719A429 /* TableStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableStyle.swift; sourceTree = "<group>"; };
 		75319B4750A1D4F87DA04721D9C33366 /* Pods-TPPDF_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TPPDF_Example-resources.sh"; sourceTree = "<group>"; };
+		792037FB206CEA4600C56D96 /* PDFGenerator+TextInline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFGenerator+TextInline.swift"; sourceTree = "<group>"; };
+		792037FE206CF0E400C56D96 /* PDFGenerator+ImageInline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFGenerator+ImageInline.swift"; sourceTree = "<group>"; };
 		8024FE3270E884F9FD724089CBA9172F /* Pods_TPPDF_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TPPDF_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8275826837E091D0ABC9AF087300C10F /* TPPDF-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TPPDF-umbrella.h"; sourceTree = "<group>"; };
 		8515A60A596F397A6B737DB3222DED70 /* Pods-TPPDF_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TPPDF_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -161,7 +165,9 @@
 				A733CBFF5DD71B04FDB75BC60DDC2079 /* PDFGenerator.swift */,
 				D4022A441EE4C70400AAA9A3 /* PDFGenerator+Lines.swift */,
 				D4022A461EE4C72300AAA9A3 /* PDFGenerator+Text.swift */,
+				792037FB206CEA4600C56D96 /* PDFGenerator+TextInline.swift */,
 				D4022A421EE4C5BA00AAA9A3 /* PDFGenerator+Image.swift */,
+				792037FE206CF0E400C56D96 /* PDFGenerator+ImageInline.swift */,
 				D4022A3C1EE4C3F100AAA9A3 /* PDFGenerator+Methods.swift */,
 				D4022A3E1EE4C43200AAA9A3 /* PDFGenerator+Generation.swift */,
 				D4022A401EE4C57D00AAA9A3 /* PDFGenerator+Table.swift */,
@@ -353,6 +359,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					FC6EBB3398BB217B61C97F01013F56B4 = {
+						LastSwiftMigration = 0920;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -398,11 +409,13 @@
 				D4022A391EE4C2D200AAA9A3 /* PDFGenerator+DocumentInfo.swift in Sources */,
 				D7A60E7AA757EA3CA97841AEFD50E178 /* Container.swift in Sources */,
 				D4022A471EE4C72300AAA9A3 /* PDFGenerator+Text.swift in Sources */,
+				792037FD206CED7900C56D96 /* PDFGenerator+TextInline.swift in Sources */,
 				ADBAFADA671E3DC3AF8AD5215D910BA6 /* PageFormat.swift in Sources */,
 				D4022A3F1EE4C43200AAA9A3 /* PDFGenerator+Generation.swift in Sources */,
 				D4022A3D1EE4C3F100AAA9A3 /* PDFGenerator+Methods.swift in Sources */,
 				A25970F20E0E42829396544F7FF47B1D /* PDFGenerator.swift in Sources */,
 				3703960108494AC861B4FE4F0DD532BA /* PDFInfo.swift in Sources */,
+				79203800206CF0EB00C56D96 /* PDFGenerator+ImageInline.swift in Sources */,
 				B0820DEEB3BE9C7B592515F80FA3E56C /* TableStyle+Defaults.swift in Sources */,
 				D4022A411EE4C57D00AAA9A3 /* PDFGenerator+Table.swift in Sources */,
 				D4022A451EE4C70400AAA9A3 /* PDFGenerator+Lines.swift in Sources */,
@@ -663,6 +676,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8515A60A596F397A6B737DB3222DED70 /* Pods-TPPDF_Example.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -702,6 +716,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E954B7FFD4B8E56AD27E0D81809ADBF5 /* Pods-TPPDF_Example.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";

--- a/Example/TPPDF.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/TPPDF.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/TPPDF/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/TPPDF/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -39,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/TPPDF/Images.xcassets/Contents.json
+++ b/Example/TPPDF/Images.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example/TPPDF/Images.xcassets/Image.imageset/Contents.json
+++ b/Example/TPPDF/Images.xcassets/Image.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "filename" : "Image.jpg",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example/TPPDF/ViewController.swift
+++ b/Example/TPPDF/ViewController.swift
@@ -24,6 +24,28 @@ class ViewController: UIViewController {
 			pdf.addImageInline(.contentRight, image: image, size: CGSize(width: 100, height: 100))
 		}
 		pdf.addTextInline(.contentCenter, text: "this is centered inline text", textMaxWidth: 100)
+		
+		pdf.addSpace(space: 50)
+		
+		pdf.addTextInline(.contentLeft, text: "left text\nfree float")
+		
+		let inlineTableData: [[String]] = [
+			["Company",                     "Contact"],
+			["Alfreds Futterkiste",         "Maria Anders"],
+			["Berglunds snabbköp",          "Christina Berglund"],
+			["Centro comercialMoctezuma",   "Francisco Chang"]
+		]
+		let inlineTableAlignment: [[TableCellAlignment]] = [
+			[.left, .left],
+			[.left, .left],
+			[.left, .left],
+			[.left, .left]
+		]
+		
+		let inlineTableWidth: [CGFloat] = [0.25, 0.25]
+		
+		let inlineTableStyle = TableStyleDefaults.simple
+		pdf.addTableInline(.contentRight, data: inlineTableData, alignment: inlineTableAlignment, relativeColumnWidth: inlineTableWidth, padding: 8, margin: 0, style: inlineTableStyle)
 		pdf.addSpace(space: 50)
         
         let tableData: [[String]] = [

--- a/Example/TPPDF/ViewController.swift
+++ b/Example/TPPDF/ViewController.swift
@@ -18,6 +18,13 @@ class ViewController: UIViewController {
     
     func generatePDF() {
         let pdf = PDFGenerator(format: .a4)
+		
+		pdf.addTextInline(.contentLeft, text: "This is left aligned inline text.\n\nUse line breaks to separate multiple items.", textMaxWidth: 100)
+		if let image = UIImage(named: "Image") {
+			pdf.addImageInline(.contentRight, image: image, size: CGSize(width: 100, height: 100))
+		}
+		pdf.addTextInline(.contentCenter, text: "this is centered inline text", textMaxWidth: 100)
+		pdf.addSpace(space: 50)
         
         let tableData: [[String]] = [
             ["",    "Company",                     "Contact",              "Country"],

--- a/Example/TPPDF/ViewController.swift
+++ b/Example/TPPDF/ViewController.swift
@@ -42,7 +42,7 @@ class ViewController: UIViewController {
 			[.left, .left]
 		]
 		
-		let inlineTableWidth: [CGFloat] = [0.25, 0.25]
+		let inlineTableWidth: [CGFloat] = [0.20, 0.20]
 		
 		let inlineTableStyle = TableStyleDefaults.simple
 		pdf.addTableInline(.contentRight, data: inlineTableData, alignment: inlineTableAlignment, relativeColumnWidth: inlineTableWidth, padding: 8, margin: 0, style: inlineTableStyle)

--- a/Sources/Command.swift
+++ b/Sources/Command.swift
@@ -20,6 +20,7 @@ public enum Command {
     case addSpace(space: CGFloat)
     case addLineSeparator(style: LineStyle)
     case addTable(data: [[String]], alignment: [[TableCellAlignment]], relativeColumnWidth: [CGFloat], padding: CGFloat, margin: CGFloat, style: TableStyle)
+	case addTableInline(data: [[String]], alignment: [[TableCellAlignment]], relativeColumnWidth: [CGFloat], padding: CGFloat, margin: CGFloat, style: TableStyle)
     
     case setIndentation(points: CGFloat)
     case setOffset(points: CGFloat)

--- a/Sources/Command.swift
+++ b/Sources/Command.swift
@@ -11,8 +11,10 @@ import UIKit
 public enum Command {
     
     case addText(text: String, lineSpacing: CGFloat)
+	case addTextInline(text: String, lineSpacing: CGFloat, textMaxWidth: CGFloat)
     case addAttributedText(text: NSAttributedString)
     case addImage(image: UIImage, size: CGSize, caption: NSAttributedString, sizeFit: ImageSizeFit)
+	case addImageInline(image: UIImage, size: CGSize, caption: NSAttributedString, sizeFit: ImageSizeFit)
     case addImagesInRow(images: [UIImage], captions: [NSAttributedString], spacing: CGFloat)
     case addSpace(space: CGFloat)
     case addLineSeparator(style: LineStyle)

--- a/Sources/Command.swift
+++ b/Sources/Command.swift
@@ -13,6 +13,7 @@ public enum Command {
     case addText(text: String, lineSpacing: CGFloat)
 	case addTextInline(text: String, lineSpacing: CGFloat, textMaxWidth: CGFloat)
     case addAttributedText(text: NSAttributedString)
+	case addAttributedTextInline(text: NSAttributedString)
     case addImage(image: UIImage, size: CGSize, caption: NSAttributedString, sizeFit: ImageSizeFit)
 	case addImageInline(image: UIImage, size: CGSize, caption: NSAttributedString, sizeFit: ImageSizeFit)
     case addImagesInRow(images: [UIImage], captions: [NSAttributedString], spacing: CGFloat)

--- a/Sources/PDFGenerator+Calculations.swift
+++ b/Sources/PDFGenerator+Calculations.swift
@@ -77,7 +77,7 @@ extension PDFGenerator {
             } else if container.isFooter {
                 return footerMargin
             } else {
-                return pageBounds.height - maxHeaderHeight() - headerSpace - maxFooterHeight() - footerSpace - contentHeight
+                return pageBounds.height - maxHeaderHeight() - headerSpace - maxFooterHeight() - footerSpace - contentHeight + contentHeightInline
             }
         }()
         

--- a/Sources/PDFGenerator+Generation.swift
+++ b/Sources/PDFGenerator+Generation.swift
@@ -15,12 +15,18 @@ extension PDFGenerator {
         case let .addText(text, spacing):
             drawText(container, text: text, spacing: spacing)
             break
+		case let .addTextInline(text, spacing, textMaxWidth):
+			drawTextInline(container, text: text, spacing: spacing, textMaxWidth: textMaxWidth)
+			break
         case let .addAttributedText(text):
             drawAttributedText(container, text: text)
             break
         case let .addImage(image, size, caption, sizeFit):
             drawImage(container, image: image, size: size, caption: caption, sizeFit: sizeFit)
             break
+		case let .addImageInline(image, size, caption, sizeFit):
+			drawImageInline(container, image: image, size: size, caption: caption, sizeFit: sizeFit)
+			break
         case let .addImagesInRow(images, captions, spacing):
             drawImagesInRow(container, images: images, captions: captions, spacing: spacing)
             break

--- a/Sources/PDFGenerator+Generation.swift
+++ b/Sources/PDFGenerator+Generation.swift
@@ -48,6 +48,9 @@ extension PDFGenerator {
         case let .addTable(data, alignment, relativeWidth, padding, margin, style):
             drawTable(container, data: data, alignments: alignment, relativeColumnWidth: relativeWidth, padding: padding, margin: margin, style: style)
             break
+		case let .addTableInline(data, alignment, relativeWidth, padding, margin, style):
+			drawTableInline(container, data: data, alignments: alignment, relativeColumnWidth: relativeWidth, padding: padding, margin: margin, style: style)
+			break
         case let .setIndentation(value):
             indentation[container.normalize] = value
             break

--- a/Sources/PDFGenerator+Generation.swift
+++ b/Sources/PDFGenerator+Generation.swift
@@ -18,9 +18,12 @@ extension PDFGenerator {
 		case let .addTextInline(text, spacing, textMaxWidth):
 			drawTextInline(container, text: text, spacing: spacing, textMaxWidth: textMaxWidth)
 			break
-        case let .addAttributedText(text):
-            drawAttributedText(container, text: text)
-            break
+		case let .addAttributedText(text):
+			drawAttributedText(container, text: text)
+			break
+		case let .addAttributedTextInline(text):
+			drawAttributedTextInline(container, text: text)
+			break
         case let .addImage(image, size, caption, sizeFit):
             drawImage(container, image: image, size: size, caption: caption, sizeFit: sizeFit)
             break

--- a/Sources/PDFGenerator+ImageInline.swift
+++ b/Sources/PDFGenerator+ImageInline.swift
@@ -121,9 +121,9 @@ extension PDFGenerator {
 		}
 		
 		if container.isHeader {
-			headerHeight[container] = headerHeight[container]! + frame.height
+			headerHeight[container] = headerHeight[container]! > frame.height ? headerHeight[container]! : frame.height
 		} else if container.isFooter {
-			footerHeight[container] = footerHeight[container]! + frame.height
+			footerHeight[container] = footerHeight[container]! > frame.height ? footerHeight[container]! : frame.height
 		} else {
 			contentHeightInline = contentHeightInline > frame.height ? contentHeightInline : frame.height
 		}

--- a/Sources/PDFGenerator+ImageInline.swift
+++ b/Sources/PDFGenerator+ImageInline.swift
@@ -1,0 +1,135 @@
+//
+//  PDFGenerator+ImageInline.swift
+//  Pods-TPPDF_Example
+//
+//  Created by Marco Betschart on 29.03.18.
+//
+
+import Foundation
+
+extension PDFGenerator {
+	
+	func drawImageInline(_ container: Container, image: UIImage, size: CGSize, caption: NSAttributedString, sizeFit: ImageSizeFit) {
+		var (imageSize, captionSize) = calculateImageCaptionSize(container, image: image, size: size, caption: caption, sizeFit: sizeFit)
+		
+		let y: CGFloat = {
+			switch container.normalize {
+			case .headerLeft:
+				return headerHeight[container]!
+			case .contentLeft:
+				if (contentHeight - contentHeightInline + imageSize.height + captionSize.height > contentSize.height || (sizeFit == .height && imageSize.height < size.height)) {
+					generateNewPage()
+					
+					(imageSize, captionSize) = calculateImageCaptionSize(container, image: image, size: size, caption: caption, sizeFit: sizeFit)
+					
+					return contentHeight - contentHeightInline + maxHeaderHeight() + headerSpace
+				}
+				return contentHeight - contentHeightInline + maxHeaderHeight() + headerSpace
+			case .footerLeft:
+				return contentSize.height + maxHeaderHeight() + footerHeight[container]!
+			default:
+				return 0
+			}
+		}()
+		
+		let x: CGFloat = {
+			switch container {
+			case .headerLeft, .contentLeft, .footerLeft:
+				return pageMargin + indentation[container.normalize]!
+			case .headerCenter, .contentCenter, .footerCenter:
+				return pageBounds.midX - imageSize.width / 2
+			case .headerRight, .contentRight, .footerRight:
+				return pageBounds.width - pageMargin - imageSize.width
+			default:
+				return 0
+			}
+		}()
+		
+		let frame = CGRect(x: x, y: y, width: imageSize.width, height: imageSize.height)
+		drawImageInline(container, image: image, frame: frame, caption: caption)
+	}
+	
+	func drawImagesInRowInline(_ container: Container, images: [UIImage], captions: [NSAttributedString], spacing: CGFloat) {
+		assert(images.count > 0, "You need to provide at least one image!")
+		
+		let totalImagesWidth = contentSize.width - indentation[container.normalize]! - (CGFloat(images.count) - 1) * spacing
+		let imageWidth = totalImagesWidth / CGFloat(images.count)
+		
+		let calculateImageCaptionSizes: ([UIImage], [NSAttributedString]) -> ([CGSize], CGFloat) = {
+			images, captions in
+			
+			var (imageSizes, maxHeight): ([CGSize], CGFloat) = ([], 0)
+			for (index, image) in images.enumerated() {
+				let caption = (captions.count > index) ? captions[index] : NSAttributedString()
+				let (imageSize, captionSize) = self.calculateImageCaptionSize(container, image: image, size: CGSize(width: imageWidth, height: image.size.height), caption: caption, sizeFit: .width)
+				imageSizes.append(imageSize)
+				
+				if maxHeight < imageSize.height + captionSize.height {
+					maxHeight = imageSize.height + captionSize.height
+				}
+			}
+			
+			return (imageSizes, maxHeight)
+		}
+		
+		var (imageSizes, maxHeight) = calculateImageCaptionSizes(images, captions)
+		
+		var y = contentHeight - contentHeightInline + maxHeaderHeight() + headerSpace
+		if (contentHeight - contentHeightInline + maxHeight > contentSize.height) {
+			generateNewPage()
+			
+			y = contentHeight - contentHeightInline + maxHeaderHeight() + headerSpace
+			(imageSizes, maxHeight) = calculateImageCaptionSizes(images, captions)
+		}
+		
+		var x: CGFloat = pageMargin + indentation[container.normalize]!
+		
+		let (nowContentHeightInline, nowIndentation) = (contentHeightInline, indentation[container.normalize]!)
+		for (index, image) in images.enumerated() {
+			let imageSize = imageSizes[index]
+			let caption = (captions.count > index) ? captions[index] : NSAttributedString()
+			drawImageInline(container, image: image, frame: CGRect(x: x, y: y, width: imageSize.width, height: imageSize.height), caption: caption)
+			
+			x += imageSize.width + spacing
+			indentation[container.normalize] = indentation[container.normalize]! + imageSize.width + spacing
+			contentHeightInline = contentHeightInline > nowContentHeightInline ? contentHeightInline : nowContentHeightInline
+		}
+		
+		indentation[container.normalize] = nowIndentation
+		contentHeightInline = contentHeightInline > maxHeight ? contentHeightInline : maxHeight
+	}
+	
+	func drawImageInline(_ container: Container, image: UIImage, frame: CGRect, caption: NSAttributedString) {
+		// resize
+		let resizeFactor = (3 * imageQuality > 1) ? 3 * imageQuality : 1
+		let resizeImageSize = CGSize(width: frame.size.width * resizeFactor, height: frame.size.height * resizeFactor)
+		
+		UIGraphicsBeginImageContext(resizeImageSize)
+		image.draw(in: CGRect(x:0, y:0, width: resizeImageSize.width, height: resizeImageSize.height))
+		var compressedImage = UIGraphicsGetImageFromCurrentImageContext()
+		UIGraphicsEndImageContext()
+		
+		// compression
+		if let image = compressedImage, let jpegData = UIImageJPEGRepresentation(image, imageQuality) {
+			compressedImage = UIImage(data: jpegData)
+		}
+		
+		if let resultImage = compressedImage {
+			resultImage.draw(in: frame)
+		} else {
+			image.draw(in: frame)
+		}
+		
+		if container.isHeader {
+			headerHeight[container] = headerHeight[container]! + frame.height
+		} else if container.isFooter {
+			footerHeight[container] = footerHeight[container]! + frame.height
+		} else {
+			contentHeightInline = contentHeightInline > frame.height ? contentHeightInline : frame.height
+		}
+		
+		if caption.length > 0 {
+			drawAttributedTextInline(container, text: caption, textMaxWidth: frame.size.width)
+		}
+	}
+}

--- a/Sources/PDFGenerator+Methods.swift
+++ b/Sources/PDFGenerator+Methods.swift
@@ -65,6 +65,16 @@ extension PDFGenerator {
         }
         commands += [(container, .addTable(data: data, alignment: alignment, relativeColumnWidth: relativeColumnWidth, padding: padding, margin: margin, style: style))]
     }
+	
+	open func addTableInline(_ container: Container = Container.contentLeft, data: [[String]], alignment: [[TableCellAlignment]], relativeColumnWidth: [CGFloat], padding: CGFloat = 0, margin: CGFloat = 0, style: TableStyle = TableStyle()) {
+		assert(data.count != 0, "You can't draw an table without rows!")
+		assert(data.count == alignment.count, "Data and alignment array must be equal size!")
+		for (rowIdx, row) in data.enumerated() {
+			assert(row.count == alignment[rowIdx].count, "Data and alignment for row with index \(rowIdx) does not have the same amount!")
+			assert(row.count == relativeColumnWidth.count, "Data and alignment for row with index \(rowIdx) does not have the same amount!")
+		}
+		commands += [(container, .addTableInline(data: data, alignment: alignment, relativeColumnWidth: relativeColumnWidth, padding: padding, margin: margin, style: style))]
+	}
 
     // MARK: - Container
     

--- a/Sources/PDFGenerator+Methods.swift
+++ b/Sources/PDFGenerator+Methods.swift
@@ -19,6 +19,10 @@ extension PDFGenerator {
     open func addText(_ container: Container = Container.contentLeft, text: String, lineSpacing: CGFloat = 1.0) {
         commands += [(container, .addText(text: text, lineSpacing: lineSpacing))]
     }
+	
+	open func addTextInline(_ container: Container = Container.contentLeft, text: String, textMaxWidth: CGFloat = 0, lineSpacing: CGFloat = 1.0) {
+		commands += [(container, .addTextInline(text: text, lineSpacing: lineSpacing, textMaxWidth: textMaxWidth))]
+	}
     
     open func addAttributedText(_ container: Container = Container.contentLeft, text: NSAttributedString) {
         commands += [(container, .addAttributedText(text: text))]
@@ -37,6 +41,10 @@ extension PDFGenerator {
     open func addImage(_ container: Container = Container.contentLeft, image: UIImage, size: CGSize = CGSize.zero, caption: NSAttributedString = NSAttributedString(), sizeFit: ImageSizeFit = .widthHeight) {
         commands += [(container, .addImage(image: image, size: size, caption: caption, sizeFit: sizeFit))]
     }
+	
+	open func addImageInline(_ container: Container = Container.contentLeft, image: UIImage, size: CGSize = CGSize.zero, caption: NSAttributedString = NSAttributedString(), sizeFit: ImageSizeFit = .widthHeight) {
+		commands += [(container, .addImageInline(image: image, size: size, caption: caption, sizeFit: sizeFit))]
+	}
     
     open func addImagesInRow(_ container: Container = Container.contentLeft, images: [UIImage], captions: [NSAttributedString] = [], spacing: CGFloat = 5.0) {
         commands += [(container, .addImagesInRow(images: images, captions: captions, spacing: spacing))]

--- a/Sources/PDFGenerator+Methods.swift
+++ b/Sources/PDFGenerator+Methods.swift
@@ -24,9 +24,13 @@ extension PDFGenerator {
 		commands += [(container, .addTextInline(text: text, lineSpacing: lineSpacing, textMaxWidth: textMaxWidth))]
 	}
     
-    open func addAttributedText(_ container: Container = Container.contentLeft, text: NSAttributedString) {
-        commands += [(container, .addAttributedText(text: text))]
-    }
+	open func addAttributedText(_ container: Container = Container.contentLeft, text: NSAttributedString) {
+		commands += [(container, .addAttributedText(text: text))]
+	}
+	
+	open func addAttributedTextInline(_ container: Container = Container.contentLeft, text: NSAttributedString) {
+		commands += [(container, .addAttributedTextInline(text: text))]
+	}
     
     open func setFont(_ container: Container = Container.contentLeft, font: UIFont) {
         commands += [(container, .setFont(font: font))]

--- a/Sources/PDFGenerator+TableInline.swift
+++ b/Sources/PDFGenerator+TableInline.swift
@@ -20,7 +20,7 @@ extension PDFGenerator {
 		if container != .contentRight {
 			x = pageMargin + indentation[container.normalize]!
 		} else {
-			x = pageBounds.size.width * relativeColumnWidth.reduce(0.0){ $0 + $1 }
+			x = totalWidth + pageMargin - totalWidth * relativeColumnWidth.reduce(0.0){ $0 + $1 }
 		}
 		var y: CGFloat = contentHeight - contentHeightInline
 		
@@ -76,7 +76,7 @@ extension PDFGenerator {
 			if container != .contentRight {
 				x = pageMargin + indentation[container.normalize]!
 			} else {
-				x = pageBounds.size.width * relativeColumnWidth.reduce(0.0){ $0 + $1 }
+				x = totalWidth + pageMargin - totalWidth * relativeColumnWidth.reduce(0.0){ $0 + $1 }
 			}
 			y += maxHeight + 2 * margin + 2 * padding
 		}

--- a/Sources/PDFGenerator+TableInline.swift
+++ b/Sources/PDFGenerator+TableInline.swift
@@ -1,0 +1,176 @@
+//
+//  PDFGenerator+TableInline.swift
+//  Pods
+//
+//  Created by Marco Betschart on 02.04.18.
+//
+
+extension PDFGenerator {
+	
+	func drawTableInline(_ container: Container, data: [[String]], alignments: [[TableCellAlignment]], relativeColumnWidth: [CGFloat], padding: CGFloat, margin: CGFloat, style: TableStyle, newPageBreak: Bool = false, styleIndexOffset: Int = 0) {
+		assert(data.count != 0, "You can't draw an table without rows!")
+		assert(data.count == alignments.count, "Data and alignment array must be equal size!")
+		for (rowIdx, row) in data.enumerated() {
+			assert(row.count == alignments[rowIdx].count, "Data and alignment for row with index \(rowIdx) does not have the same amount!")
+			assert(row.count == relativeColumnWidth.count, "Data and alignment for row with index \(rowIdx) does not have the same amount!")
+		}
+		
+		let totalWidth = pageBounds.width - 2 * pageMargin - indentation[container.normalize]!
+		var x: CGFloat
+		if container != .contentRight {
+			x = pageMargin + indentation[container.normalize]!
+		} else {
+			x = pageBounds.size.width * relativeColumnWidth.reduce(0.0){ $0 + $1 }
+		}
+		var y: CGFloat = contentHeight - contentHeightInline
+		
+		// Calculate cells
+		
+		var cellFrames: [[CGRect]] = []
+		var frames: [[CGRect]] = []
+		
+		for (rowIdx, row) in data.enumerated() {
+			frames.append([])
+			cellFrames.append([])
+			
+			var maxHeight: CGFloat = 0
+			
+			// Calcuate X position and size
+			for (colIdx, column) in row.enumerated() {
+				let cellStyle = getCellStyle(tableHeight: data.count + styleIndexOffset, style: style, row: styleIndexOffset + rowIdx, column: colIdx, newPageBreak: newPageBreak)
+				let attributes: [String: AnyObject] = [
+					NSForegroundColorAttributeName: cellStyle.textColor,
+					NSFontAttributeName: cellStyle.font
+				]
+				
+				let text = NSAttributedString(string: column, attributes: attributes)
+				let width = relativeColumnWidth[colIdx] * totalWidth
+				let result = calculateCellFrame(CGPoint(x: x + margin + padding, y: y + maxHeaderHeight() + headerSpace + margin + padding), width: width - 2 * margin - 2 * padding, text: text, alignment: alignments[rowIdx][colIdx])
+				
+				maxHeight = max(maxHeight, result.height)
+				frames[rowIdx].append(result)
+				
+				let cellFrame = CGRect(x: x + margin, y: y + maxHeaderHeight() + headerSpace + margin, width: width - 2 * margin, height: result.height);
+				cellFrames[rowIdx].append(cellFrame)
+				
+				x += width
+			}
+			
+			// Reposition in Y-Axis
+			for (colIdx, _) in row.enumerated() {
+				let alignment = alignments[rowIdx][colIdx]
+				let frame = frames[rowIdx][colIdx]
+				let y: CGFloat = {
+					switch alignment.normalizeVertical {
+					case .center:
+						return frame.minY + (maxHeight - frame.height) / 2
+					case .bottom:
+						return frame.minY + maxHeight - frame.height
+					default:
+						return frame.minY
+					}
+				}()
+				frames[rowIdx][colIdx].origin.y = y
+			}
+			
+			if container != .contentRight {
+				x = pageMargin + indentation[container.normalize]!
+			} else {
+				x = pageBounds.size.width * relativeColumnWidth.reduce(0.0){ $0 + $1 }
+			}
+			y += maxHeight + 2 * margin + 2 * padding
+		}
+		
+		// Divide tables according to contentSize
+		var (dataInThisPage, alignmentsInThisPage, framesInThisPage): ([[String]], [[TableCellAlignment]], [[CGRect]]) = ([], [], [])
+		var (dataInNewPage, alignmentsInNewPage): ([[String]], [[TableCellAlignment]]) = ([], [])
+		var totalHeight: CGFloat = 0
+		
+		for (rowIdx, row) in data.enumerated() {
+			let maxHeight = frames[rowIdx].reduce(0) { max($0, $1.height) }
+			let cellHeight = maxHeight + 2 * padding
+			
+			if (frames[rowIdx][0].origin.y + cellHeight > contentSize.height + maxHeaderHeight() + headerSpace) {
+				dataInNewPage.append(row)
+				alignmentsInNewPage.append(alignments[rowIdx])
+			} else {
+				dataInThisPage.append(row)
+				alignmentsInThisPage.append(alignments[rowIdx])
+				framesInThisPage.append(frames[rowIdx])
+				
+				totalHeight += cellHeight + 2 * margin
+			}
+			for (idx, frame) in cellFrames[rowIdx].enumerated() {
+				var newFrame = frame
+				newFrame.size.height = cellHeight
+				cellFrames[rowIdx][idx] = newFrame
+			}
+		}
+		
+		// Draw background
+		
+		for (rowIdx, row) in dataInThisPage.enumerated() {
+			for (colIdx, _) in row.enumerated() {
+				let cellStyle = getCellStyle(tableHeight: data.count + styleIndexOffset, style: style, row: styleIndexOffset + rowIdx, column: colIdx, newPageBreak: newPageBreak)
+				let cellFrame = cellFrames[rowIdx][colIdx]
+				
+				let path = UIBezierPath(rect: cellFrame).cgPath
+				
+				let currentContext = UIGraphicsGetCurrentContext()!
+				
+				cellStyle.fillColor.setFill()
+				currentContext.addPath(path)
+				currentContext.drawPath(using: .fill)
+			}
+		}
+		
+		// Draw text
+		
+		for (rowIdx, row) in dataInThisPage.enumerated() {
+			for (colIdx, text) in row.enumerated() {
+				let cellStyle = getCellStyle(tableHeight: data.count + styleIndexOffset, style: style, row: styleIndexOffset + rowIdx, column: colIdx, newPageBreak: newPageBreak)
+				
+				let attributes: [String: AnyObject] = [
+					NSForegroundColorAttributeName: cellStyle.textColor,
+					NSFontAttributeName: cellStyle.font
+				]
+				
+				let textFrame = framesInThisPage[rowIdx][colIdx]
+				let attributedText = NSAttributedString(string: text, attributes: attributes)
+				// the last line of text is hidden if 30 is not added
+				attributedText.draw(in: CGRect(origin: textFrame.origin, size: CGSize(width: textFrame.width, height: textFrame.height + 20)))
+			}
+		}
+		
+		// Draw grid lines
+		
+		for (rowIdx, row) in dataInThisPage.enumerated() {
+			for (colIdx, _) in row.enumerated() {
+				let cellStyle = getCellStyle(tableHeight: data.count + styleIndexOffset, style: style, row: styleIndexOffset + rowIdx, column: colIdx, newPageBreak: newPageBreak)
+				let cellFrame = cellFrames[rowIdx][colIdx]
+				
+				drawLine(start: CGPoint(x: cellFrame.minX, y: cellFrame.minY), end: CGPoint(x: cellFrame.maxX, y: cellFrame.minY), style: cellStyle.borderTop)
+				drawLine(start: CGPoint(x: cellFrame.minX, y: cellFrame.maxY), end: CGPoint(x: cellFrame.maxX, y: cellFrame.maxY), style: cellStyle.borderBottom)
+				drawLine(start: CGPoint(x: cellFrame.minX, y: cellFrame.minY), end: CGPoint(x: cellFrame.minX, y: cellFrame.maxY), style: cellStyle.borderLeft)
+				drawLine(start: CGPoint(x: cellFrame.maxX, y: cellFrame.minY), end: CGPoint(x: cellFrame.maxX, y: cellFrame.maxY), style: cellStyle.borderRight)
+			}
+		}
+		
+		// Draw table outline
+		
+		let tableFrame = CGRect(x: x, y: contentHeightInline + maxHeaderHeight() + headerSpace, width: totalWidth, height: totalHeight)
+		drawLine(start: CGPoint(x: tableFrame.minX, y: tableFrame.minY), end: CGPoint(x: tableFrame.maxX, y: tableFrame.minY), style: style.outline)
+		drawLine(start: CGPoint(x: tableFrame.minX, y: tableFrame.maxY), end: CGPoint(x: tableFrame.maxX, y: tableFrame.maxY), style: style.outline)
+		drawLine(start: CGPoint(x: tableFrame.minX, y: tableFrame.minY), end: CGPoint(x: tableFrame.minX, y: tableFrame.maxY), style: style.outline)
+		drawLine(start: CGPoint(x: tableFrame.maxX, y: tableFrame.minY), end: CGPoint(x: tableFrame.maxX, y: tableFrame.maxY), style: style.outline)
+		
+		// Continue with table on next page
+		
+		if !dataInNewPage.isEmpty {
+			generateNewPage()
+			drawTableInline(container, data: dataInNewPage, alignments: alignmentsInNewPage, relativeColumnWidth: relativeColumnWidth, padding: padding, margin: margin, style: style, newPageBreak: true, styleIndexOffset: dataInThisPage.count)
+		} else {
+			contentHeightInline = tableFrame.maxY - maxHeaderHeight() - headerSpace
+		}
+	}
+}

--- a/Sources/PDFGenerator+Text.swift
+++ b/Sources/PDFGenerator+Text.swift
@@ -60,25 +60,4 @@ extension PDFGenerator {
             }
         } while(!done)
     }
-    
-    func generateDefaultTextAttributes(_ container: Container, spacing: CGFloat) -> [String: NSObject] {
-        let paragraphStyle = NSMutableParagraphStyle()
-        switch container {
-        case .headerLeft, .contentLeft, .footerLeft:
-            paragraphStyle.alignment = .left
-        case .headerCenter, .contentCenter, .footerCenter:
-            paragraphStyle.alignment = .center
-        case .headerRight, .contentRight, .footerRight:
-            paragraphStyle.alignment = .right
-        default:
-            paragraphStyle.alignment = .left
-        }
-        
-        paragraphStyle.lineSpacing = spacing
-        
-        return [
-            NSFontAttributeName: fonts[container]!,
-            NSParagraphStyleAttributeName: paragraphStyle
-        ]
-    }
 }

--- a/Sources/PDFGenerator+TextInline.swift
+++ b/Sources/PDFGenerator+TextInline.swift
@@ -1,0 +1,83 @@
+//
+//  PDFGenerator+TextInline.swift
+//  Pods-TPPDF_Example
+//
+//  Created by Marco Betschart on 29.03.18.
+//
+
+extension PDFGenerator {
+	
+	func drawTextInline(_ container: Container, text: String, spacing: CGFloat, textMaxWidth: CGFloat = 0) {
+		let attributes = generateDefaultTextAttributes(container, spacing: spacing)
+		
+		drawAttributedTextInline(container, text: NSAttributedString(string: text, attributes: attributes), textMaxWidth: textMaxWidth)
+	}
+	
+	func drawAttributedTextInline(_ container: Container, text: NSAttributedString, textMaxWidth: CGFloat = 0) {
+		let currentText = CFAttributedStringCreateCopy(nil, text as CFAttributedString)
+		var currentRange = CFRange(location: 0, length: 0)
+		var done = false
+		
+		repeat {
+			let (frameRef, drawnSize) = calculateTextFrameAndDrawnSizeInOnePage(container, text: currentText!, currentRange: currentRange, textMaxWidth: textMaxWidth)
+			// Get the graphics context.
+			let currentContext = UIGraphicsGetCurrentContext()!
+			
+			// Push state
+			currentContext.saveGState()
+			
+			// Put the text matrix into a known state. This ensures
+			// that no old scaling factors are left in place.
+			currentContext.textMatrix = CGAffineTransform.identity
+			
+			// Core Text draws from the bottom-left corner up, so flip
+			// the current transform prior to drawing.
+			currentContext.translateBy(x: 0, y: pageBounds.height)
+			currentContext.scaleBy(x: 1.0, y: -1.0)
+			
+			// Draw the frame.
+			CTFrameDraw(frameRef, currentContext)
+			
+			// Pop state
+			currentContext.restoreGState()
+			
+			// Update the current range based on what was drawn.
+			let visibleRange = CTFrameGetVisibleStringRange(frameRef)
+			currentRange = CFRange(location: visibleRange.location + visibleRange.length , length: 0)
+			
+			if container.isHeader {
+				headerHeight[container] = headerHeight[container]! + drawnSize.height
+			} else if container.isFooter {
+				footerHeight[container] = footerHeight[container]! + drawnSize.height
+			} else {
+				contentHeightInline = contentHeightInline > drawnSize.height ? contentHeightInline : drawnSize.height
+			}
+			if currentRange.location == CFAttributedStringGetLength(currentText) {
+				done = true
+			} else {
+				generateNewPage()
+			}
+		} while(!done)
+	}
+	
+	func generateDefaultTextAttributes(_ container: Container, spacing: CGFloat) -> [String: NSObject] {
+		let paragraphStyle = NSMutableParagraphStyle()
+		switch container {
+		case .headerLeft, .contentLeft, .footerLeft:
+			paragraphStyle.alignment = .left
+		case .headerCenter, .contentCenter, .footerCenter:
+			paragraphStyle.alignment = .center
+		case .headerRight, .contentRight, .footerRight:
+			paragraphStyle.alignment = .right
+		default:
+			paragraphStyle.alignment = .left
+		}
+		
+		paragraphStyle.lineSpacing = spacing
+		
+		return [
+			NSFontAttributeName: fonts[container]!,
+			NSParagraphStyleAttributeName: paragraphStyle
+		]
+	}
+}

--- a/Sources/PDFGenerator+TextInline.swift
+++ b/Sources/PDFGenerator+TextInline.swift
@@ -46,9 +46,9 @@ extension PDFGenerator {
 			currentRange = CFRange(location: visibleRange.location + visibleRange.length , length: 0)
 			
 			if container.isHeader {
-				headerHeight[container] = headerHeight[container]! + drawnSize.height
+				headerHeight[container] = headerHeight[container]! > drawnSize.height ? headerHeight[container]! : drawnSize.height
 			} else if container.isFooter {
-				footerHeight[container] = footerHeight[container]! + drawnSize.height
+				footerHeight[container] = footerHeight[container]! > drawnSize.height ? footerHeight[container]! : drawnSize.height
 			} else {
 				contentHeightInline = contentHeightInline > drawnSize.height ? contentHeightInline : drawnSize.height
 			}

--- a/Sources/PDFGenerator.swift
+++ b/Sources/PDFGenerator.swift
@@ -42,7 +42,18 @@ open class PDFGenerator  {
     
     var headerHeight: [Container : CGFloat] = [:]
     var footerHeight: [Container : CGFloat] = [:]
-    var contentHeight: CGFloat = 0
+	
+	private var contentHeightBlock: CGFloat = 0
+	
+	var contentHeight: CGFloat {
+		get { return contentHeightBlock + contentHeightInline }
+		set {
+			contentHeightBlock = newValue
+			contentHeightInline = 0
+		}
+	}
+	
+	var contentHeightInline: CGFloat = 0
     
     var contentSize: CGSize {
         return CGSize(width: pageBounds.width - 2 * pageMargin, height: pageBounds.height - maxHeaderHeight() - headerSpace - maxFooterHeight() - footerSpace)


### PR DESCRIPTION
Added basic inline commands (`addTextInline`, `addImageInline`, `addTableInline`) to place objects next to each other on the same line.

This pull requests works around current limitations mentioned in https://github.com/Techprimate/TPPDF/issues/50

<img width="327" alt="bildschirmfoto 2018-03-29 um 12 20 56" src="https://user-images.githubusercontent.com/392542/38084255-71e6bf6a-334c-11e8-88b8-84c73b14ecd7.png">


Please note that this does not work 100% under every circumstances. Known limitations:
- Inline items can only be added to content containers (`.contentLeft`,`.contentCenter` and `.contentRight`)
- `addTableInline` does **not** work for `.contentCenter` (only `.contentLeft` and `.contentRight`)
- Adding multiple inline items to the same container is not supported - except you have a block element in between (e.g.: `.addTextInline(.contentLeft, ...), .addSpace(), .addTextInline(.contentLeft, ...)`
- Image captions are not supported

For now it works good enough [till the rewrite of the new version is complete](https://github.com/Techprimate/TPPDF/issues/29). Hopefully inline items will be supported in the new version?