### PR TITLE
Enhancement: Add possibility to draw a bordered PDFTable with corners radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Each cell has an optional `content` of type `PDFTableContent`, an optional `styl
 
 ##### Alignment
 
-The aligmnet is one of the following `PDFTableCellAlignment`:
+The alignment is one of the following `PDFTableCellAlignment`:
 
 - `topLeft`, `top`, `topRight`
 - `left`, `center`, `right`
@@ -401,6 +401,7 @@ All other cells are styled using the `style.contentStyle` and if the optional va
 
 If there are conflicts, e.g a cell is a column and a header row, then the following priority order, with the higher ones beating the lower ones, is used:
 
+- `style.outline` can receive a `PDFLineStyle` to draw table borders. PDFLineStyle can take radius `CGFloat?` propriety to define radius border. This proprity is only used when drawing a rect, like table. 
 - `cell.style`, a custom style set for this particular cell
 - `style.columnHeaderStyle`, if the cell is a column header therefore in the top rows
 - `style.footerStyle`, if the cell is a footer row

--- a/Source/Graphics/PDFGraphics.swift
+++ b/Source/Graphics/PDFGraphics.swift
@@ -105,11 +105,13 @@ class PDFGraphics {
      */
     static func createRectPath(rect: CGRect, outline: PDFLineStyle) -> UIBezierPath {
         var path = UIBezierPath(rect: rect)
+        if let radius = outline.radius {
+            path = UIBezierPath.init(roundedRect: rect, cornerRadius: radius)
+        }
 
         let dashes = createDashes(style: outline, path: &path)
         path.setLineDash(dashes, count: dashes.count, phase: 0.0)
         path.lineWidth = CGFloat(outline.width)
-
         return path
     }
 

--- a/Source/Graphics/PDFLineStyle.swift
+++ b/Source/Graphics/PDFLineStyle.swift
@@ -26,16 +26,23 @@ public struct PDFLineStyle: PDFJSONSerializable {
     public var width: CGFloat
 
     /**
+     Defines the width of this radius (Only for rect draw, not for line)
+     */
+    public var radius: CGFloat?
+
+    /**
      Initialize a table line style
 
      - parameter type: of Line
      - parameter color: of Line
      - parameter width: of Line
+     - parameter radius: of border
      */
-    public init(type: PDFLineType = .full, color: UIColor = .black, width: CGFloat = 0.25) {
+    public init(type: PDFLineType = .full, color: UIColor = .black, width: CGFloat = 0.25, radius:CGFloat? = nil) {
         self.type = type
         self.color = color
         self.width = width
+        self.radius = radius
     }
 
     /**

--- a/Source/Section/PDFSectionObject.swift
+++ b/Source/Section/PDFSectionObject.swift
@@ -67,7 +67,7 @@ class PDFSectionObject: PDFObject {
 				contentMinY = currentObject.frame.minY
 			}
 		}
-		generator.setContentOffset(in: container, to: (contentMaxY ?? 0) - (contentMinY ?? 0))
+		generator.setContentOffset(in: container, to: (contentMaxY ?? 0) - (contentMinY ?? 0) + originalContentOffset)
 
 		return result
 	}


### PR DESCRIPTION
Hello, 
First, thank you for your work it's been a long time that I searching for a really good PDF creator and you did it! 👍
But now, I need to copy my old HTML generated pdf to your great solution but i've border radius on it and I saw you don't add this possibility when we draw rect like tables... So, I enhance a little bit `PDFGraphics.createRectPath` =).

Please find details below :

__Solution:__ 
Add `radius` propriety on `PDFLineStyle`. Inside `PDFGraphics.createRectPath(rect:, outline:)` if the radius propriety of `outline` is not nil, we will use `UIBezierPath.init(roundedRect:, cornerRadius:)`
Corner radius parameter will be filled with `PDFLineStyle.radius`.

__Changes to be committed:__
	modified:   README.md
	modified:   Source/Graphics/PDFGraphics.swift
	modified:   Source/Graphics/PDFLineStyle.swift