### PR TITLE
Update Error Message to better reflect the issue

### DIFF
--- a/Source/Table/PDFTableValidator.swift
+++ b/Source/Table/PDFTableValidator.swift
@@ -64,7 +64,7 @@ class PDFTableValidator {
 
             // Throw error when columns row count does not equal relativeColumnWidth count
             if columnWidths != nil && row.count != columnWidths!.count {
-                throw PDFError.tableStructureInvalid(message: "Data and alignment for row with index \(rowIdx) does not have the same amount!")
+                throw PDFError.tableStructureInvalid(message: "Data and widths for row with index \(rowIdx) does not have the same amount!")
             }
         }
     }


### PR DESCRIPTION
The term Alignments was a misleading error when the problem is the widths are either missing or do not match the number of data elements.