### PR TITLE
Fixed bugs #73, #86, #90

### DIFF
--- a/Source/Layout/PDFSpaceObject.swift
+++ b/Source/Layout/PDFSpaceObject.swift
@@ -37,24 +37,28 @@ class PDFSpaceObject: PDFObject {
     override func calculate(generator: PDFGenerator, container: PDFContainer) throws -> [(PDFContainer, PDFObject)] {
         let document = generator.document
 
+        let expectedY = document.layout.margin.bottom
+            + generator.layout.heights.maxHeaderHeight()
+            + document.layout.space.header
+            + generator.layout.heights.content
+        let maxY = document.layout.margin.top
+            + generator.layout.heights.maxHeaderHeight()
+            + document.layout.space.header
+            + document.layout.contentSize.height
         let origin = CGPoint(
             x: document.layout.margin.left
                 + generator.layout.indentation.leftIn(container: container),
-            y: document.layout.margin.bottom
-                + generator.layout.heights.maxHeaderHeight()
-                + document.layout.space.header
-                + generator.layout.heights.content
-        )
+            y: expectedY > maxY ? maxY : expectedY)
 
         let width = document.layout.size.width
             - document.layout.margin.left
             - generator.layout.indentation.leftIn(container: container)
             - generator.layout.indentation.rightIn(container: container)
             - document.layout.margin.right
+        let height = min(space, maxY - origin.y)
+        self.frame = CGRect(x: origin.x, y: origin.y, width: width, height: height)
 
-        self.frame = CGRect(x: origin.x, y: origin.y, width: width, height: space)
-
-        generator.layout.heights.add(space, to: container)
+        generator.layout.heights.add(height, to: container)
 
         return [(container, self)]
     }

--- a/Source/Section/PDFSectionObject.swift
+++ b/Source/Section/PDFSectionObject.swift
@@ -67,7 +67,8 @@ class PDFSectionObject: PDFObject {
 				contentMinY = currentObject.frame.minY
 			}
 		}
-		generator.setContentOffset(in: container, to: (contentMaxY ?? 0) - (contentMinY ?? 0) + originalContentOffset)
+        let containsBreak = result.contains(where: { $0.1 is PDFPageBreakObject })
+        generator.setContentOffset(in: container, to: (contentMaxY ?? 0) - (contentMinY ?? 0) + (containsBreak ? 0 : originalContentOffset))
 
 		return result
 	}


### PR DESCRIPTION
Fixed bugs with wrong layout when content is near the end of the page https://github.com/Techprimate/TPPDF/issues/73#issuecomment-430662634
Also could be related to  #86, #90

        //bug #1
        document.addSpace(space: 600)
        let section = PDFSection(columnWidths: [0.33, 0.34, 0.33])
        section.columns[0].addText(text: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.")
        document.addSection(section)

        document.addText(text: "this text positioned in a wrong way")

http://prntscr.com/l75rk5

        //bug #2
        document.addSpace(space: 670)
        document.addSpace(space: 70)
        document.addText(text: "this text positioned in a wrong way")

http://prntscr.com/lqac12