### PR TITLE
#267: Fixed available height calculation in PDFCalculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@
 
 **Fixed bugs:**
 
+- Fixed `PDFList` not calculating available content height correctly (#267)
+
 **Closed issues:**
+
+- Issue #267
 
 **Merged pull requests:**
 
+- PR #268 (by philprime)
+
 ## [2.3.4](https://github.com/techprimate/TPPDF/tree/2.3.4) (2021-03-15)
 [Full Changelog](https://github.com/techprimate/TPPDF/compare/2.3.3...2.3.4)
-
-**Implemented enhancements:**
 
 **Fixed bugs:**
 

--- a/Shared/Examples/ExperimentFactory.swift
+++ b/Shared/Examples/ExperimentFactory.swift
@@ -14,12 +14,37 @@ class ExperimentFactory: ExampleFactory {
     func generateDocument() -> [PDFDocument] {
         let document = PDFDocument(format: .a4)
 
-        document.pagination = .init(container: .footerRight)
-        
-        let externalDocument = PDFExternalDocument(url: Bundle.main.url(forResource: "sample-large", withExtension: "pdf")!)
-        document.add(externalDocument: externalDocument)
+        let items = (0..<40).map { $0.description }
 
-        document.add(text: "END")
+        // Simple bullet point list
+        let featureList = PDFList(indentations: [
+            (pre: 10.0, past: 20.0),
+            (pre: 20.0, past: 20.0),
+            (pre: 40.0, past: 20.0)
+        ])
+
+        // By adding the item first to a list item with the dot symbol, all of them will inherit it
+        featureList
+            .addItem(PDFListItem(symbol: .dot)
+                        .addItems(items.map({ item in
+                            PDFListItem(content: item)
+                        })))
+        document.add(list: featureList)
+
+        document.add(space: 20)
+
+        // Numbered list with unusual indentation
+        let weirdIndentationList = PDFList(indentations: [
+            (pre: 10.0, past: 20.0),
+            (pre: 40.0, past: 30.0),
+            (pre: 20.0, past: 50.0)
+        ])
+
+        weirdIndentationList
+            .addItems(items.enumerated().map({ arg in
+                PDFListItem(symbol: .numbered(value: "\(arg.offset + 1)"), content: arg.element)
+            }))
+        document.add(list: weirdIndentationList)
 
         return [document]
     }

--- a/Source/Internal/Utils/PDFCalculations.swift
+++ b/Source/Internal/Utils/PDFCalculations.swift
@@ -56,7 +56,7 @@ internal enum PDFCalculations {
      Calculates the actual size of the text and the remainder which does not fit the given `bounds`
 
      - parameter text: Text which is calculated
-     - paramter bounds: Bounds where text should fit
+     - parameter bounds: Bounds where text should fit
 
      - returns: Tuple of `text`, real `size of the text and the `remainder`
      */
@@ -136,9 +136,12 @@ internal enum PDFCalculations {
     ///         ┠┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┨
     ///         ┃ header spacing ┃
     ///         ┠┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┨
-    ///     --> ┃┌──────────────┐┃ <-- top minimum
-    ///      ↕︎  ┃│    Group     │┃
-    ///     --> ┃└──────────────┘┃ <-- bottom maximum
+    ///         ┃┌──────────────┐┃ <-- top minimum
+    ///         ┃│    content   │┃
+    ///         ┃└──────────────┘┃
+    ///     --> ┃                ┃
+    ///      ↕︎  ┃                ┃
+    ///     --> ┃                ┃ <-- bottom maximum
     ///         ┠┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┨
     ///         ┃ footer spacing ┃
     ///         ┠┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┨
@@ -156,7 +159,7 @@ internal enum PDFCalculations {
         if container.isHeader || container.isFooter {
             return pageLayout.height
         }
-        return calculateBottomMaximum(for: generator) - calculateTopMinimum(for: generator)
+        return calculateBottomMaximum(for: generator) - calculateTopMinimum(for: generator) - generator.layout.heights.content
     }
 
     /// Calculates the minimum offset from the top edge where content should start


### PR DESCRIPTION
This affected the page content height used to break lists.
Might have consequences for tables, can't confirm/deny at the moment