### PR TITLE
Add option to avoid page breaks in table cells (fixes #279).

### DIFF
--- a/Source/API/Layout/PDFPageBreakMode.swift
+++ b/Source/API/Layout/PDFPageBreakMode.swift
@@ -1,0 +1,18 @@
+//
+//  PageBreakMode.swift
+//  TPPDF
+//
+//  Created by James Wild on 15/06/2021.
+//
+
+import Foundation
+
+/// Specifies how page breaks are to be handled:
+/// - never: Avoid page breaks by moving to the next page. If taller than a page, the PDF will fail to generate as a page break is inevitable.
+/// - avoid: Avoid page breaks by moving to the next page. If taller than a page, split at page breaks.
+/// - allow: Split wherever a page break happens to land.
+public enum PDFPageBreakMode {
+    case never
+    case avoid
+    case allow
+}

--- a/Source/API/Table/PDFTable.swift
+++ b/Source/API/Table/PDFTable.swift
@@ -48,9 +48,9 @@ public class PDFTable: PDFDocumentObject {
     public var showHeadersOnEveryPage: Bool = false
 
     /**
-     Cells should split when overlapping page
+     Specifies how page breaks should be handled
      */
-    public var shouldSplitCellsOnPageBreak = false
+    public var pageBreakMode: PDFPageBreakMode = .never
 
     /**
      Count of rows and columns in this table

--- a/TPPDF.xcodeproj/project.pbxproj
+++ b/TPPDF.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		95D850F22678B452002C7762 /* PDFPageBreakMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D850F12678B452002C7762 /* PDFPageBreakMode.swift */; };
 		D47CBEDB25A3AFD90071CD3A /* EmptyDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47CBEDA25A3AFD90071CD3A /* EmptyDocumentTests.swift */; };
 		D48008C025A200AD00CFB266 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D48008BF25A200AD00CFB266 /* XCTest.framework */; };
 		D48008C125A200AD00CFB266 /* XCTest.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D48008BF25A200AD00CFB266 /* XCTest.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -620,6 +621,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		95D850F12678B452002C7762 /* PDFPageBreakMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PDFPageBreakMode.swift; sourceTree = "<group>"; };
 		"CwlCatchException::CwlCatchException::Product" /* CwlCatchException.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CwlCatchException.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"CwlCatchException::CwlCatchExceptionSupport::Product" /* CwlCatchExceptionSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CwlCatchExceptionSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"CwlPreconditionTesting::CwlMachBadInstructionHandler::Product" /* CwlMachBadInstructionHandler.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CwlMachBadInstructionHandler.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1520,6 +1522,7 @@
 		OBJ_27 /* Layout */ = {
 			isa = PBXGroup;
 			children = (
+				95D850F12678B452002C7762 /* PDFPageBreakMode.swift */,
 				OBJ_28 /* PDFContainer.swift */,
 				OBJ_29 /* PDFPageLayout.swift */,
 			);
@@ -2603,6 +2606,7 @@
 				OBJ_626 /* PDFTableOfContent.swift in Sources */,
 				OBJ_627 /* NSAttributedString+PDFTableContent.swift in Sources */,
 				OBJ_628 /* Number+PDFTableContentable.swift in Sources */,
+				95D850F22678B452002C7762 /* PDFPageBreakMode.swift in Sources */,
 				OBJ_629 /* PDFTableContent+ContentType.swift in Sources */,
 				OBJ_630 /* PDFTableContent.swift in Sources */,
 				OBJ_631 /* PDFTableContentable.swift in Sources */,

--- a/Tests/TPPDFTests/Internal/Table/PDFTableObjectSpec.swift
+++ b/Tests/TPPDFTests/Internal/Table/PDFTableObjectSpec.swift
@@ -219,7 +219,7 @@ class PDFTableObjectSpec: XCTestCase {
         table.widths = [0.1, 0.3, 0.3, 0.3]
         table.margin = 10
         table.padding = 10
-        table.shouldSplitCellsOnPageBreak = false
+        table.pageBreakMode = .never
         table.style.columnHeaderCount = 3
 
         for row in 0..<table.size.rows {


### PR DESCRIPTION
This attempts to add a new "avoid" option to table cell page splitting behavior.  This will move a previously unsplit cell to the next page if it overlaps the page break, but allow splitting once moved to the next page (rather than raising an error as present).

This allows for tables which do not split over page breaks most of the time, but will split when there is no choice.