### PR TITLE
Replace class-only protocol from class to AnyObject

### DIFF
--- a/Source/API/PDFGeneratorProtocol.swift
+++ b/Source/API/PDFGeneratorProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  Protocol including all public methods and accessors available for generating documents
  */
-public protocol PDFGeneratorProtocol: class {
+public protocol PDFGeneratorProtocol: AnyObject {
 
     /**
      Instance of  `Progress` used to track and control the multi-document generation


### PR DESCRIPTION
From Swift 4, class keyword is deprecated