### PR TITLE
Fix link frames that don't start on the first line

### DIFF
--- a/Source/Internal/Text/PDFAttributedTextObject.swift
+++ b/Source/Internal/Text/PDFAttributedTextObject.swift
@@ -197,12 +197,24 @@ internal class PDFAttributedTextObject: PDFRenderObject {
                                     height: ascent + descent + leading)
             lineMetrics.append((line: line, bounds: lineBounds, range: CTLineGetStringRange(line)))
         }
+        
         for link in links {
+            guard let url = URL(string: link.url) else {
+                continue
+            }
+            
+            var found = false
             for metric in lineMetrics {
-                guard let intersection = NSRange(location: metric.range.location, length: metric.range.length).intersection(link.range),
-                      let url = URL(string: link.url) else {
-                    break
+                guard let intersection = NSRange(location: metric.range.location, length: metric.range.length).intersection(link.range) else {
+                    if found {
+                        break
+                    } else {
+                        continue
+                    }
                 }
+                
+                found = true
+                
                 let startOffset = CTLineGetOffsetForStringIndex(metric.line, intersection.location, nil)
                 let endOffset = CTLineGetOffsetForStringIndex(metric.line, intersection.location + intersection.length, nil)
 


### PR DESCRIPTION
Before:
<img width="1105" alt="image" src="https://github.com/techprimate/TPPDF/assets/80599/6ecd9cb6-7555-47f8-aa34-92a8a5398c2f">

After:
<img width="1105" alt="image" src="https://github.com/techprimate/TPPDF/assets/80599/77652c84-17ee-4f8d-82d6-592ec86d4ca3">
