### PR TITLE
Fetch objects from /add objects to a given `PDFGroup`

### DIFF
--- a/Source/API/Groups/PDFGroup+Objects.swift
+++ b/Source/API/Groups/PDFGroup+Objects.swift
@@ -12,6 +12,26 @@
 #endif
 
 public extension PDFGroup {
+  //MARK: Fetch objects and add rendered objects
+  /**
+   * Returns all objects in the group
+   * - Returns: Array of tuples containing the container and the render object
+   */
+  func getObjects() -> [(PDFGroupContainer, PDFRenderObject)] {
+    return objects
+  }
+
+  /**
+   * Adds a render object to the group in the given container
+   * - Parameter container: Container where the object will be set
+   * - Parameter renderObject: Render object to be added
+   */
+  func add(_ container: PDFGroupContainer, _ renderObject: PDFRenderObject) {
+    objects.append((container, renderObject))
+  }
+}
+
+public extension PDFGroup {
     // MARK: - PUBLIC FUNCS
 
     // MARK: - Layout


### PR DESCRIPTION
In an app where I was using the package, I was confronted with the problem that I had already rendered content in a `PDFGroup` that I wanted to add to another `PDFGroup`.

I am very sure that I am holding it extremely wrong and that there must be another solution to this problem already that I am not seeing–but at the same time, I came up with a solution that works for me:
- creating a getter to fetch the internal `PDFGroup.objects` array
- creating the func `PDFGroup.add(_:_:)` to to add an `object` (which is a tuple of `PDFGroupContainer` and `PDFRenderObject` to a `PDFGroup`

Since `PDFGroup.objects` is internal, an `extension` from my own app didn't work–so I added the code to the package itself.

I had this solution of mine in place now for a few months, but due to some git actions it seemed that my change had dissappeared from my local copy of the package–which meant I had to understand the problem (again) and reimplement my solution.

This time around I decided to fork the project though to not end up in a place where I have to reconstruct everything again–and also I thought, perhaps it might be of use to others as well, so why not create a pull request for it.

I am not that experienced when it comes to participating in open source, so let me know what I can improve on, if something comes to mind.

**Also, and I'm repeating myself here, I am quite sure there must be a better solution to my problem–so if you can hint to that so that I can get rid of this hack again, please let me know**